### PR TITLE
add prop to hide bullets on a per-page-basis

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ pageInfoTextSeparator | string | ' / ' | separator for `{currentPage}` and `{tot
 bullets | bool | false | wether to show "bullets" at the bottom of the carousel
 bulletStyle | style | null | style for each bullet
 bulletsContainerStyle | style | null | style for the bullets container
-chosenBulletStyle | stlye | null | style for the selected bullet
+chosenBulletStyle | style | null | style for the selected bullet
+hideBulletsIndices | array | [] | overrides display of bullets on a per-page-basis
 **Arrows** | --- | --- | ---
 arrows | bool | false | wether to show navigation arrows for the carousel
 arrowsStyle | style | null | style for navigation arrows

--- a/index.js
+++ b/index.js
@@ -39,6 +39,7 @@ export default class Carousel extends Component {
     bullets: PropTypes.bool,
     bulletsContainerStyle: Text.propTypes.style,
     bulletStyle: Text.propTypes.style,
+    hideBulletsIndices: PropTypes.arrayOf(PropTypes.number),
     arrows: PropTypes.bool,
     arrowsContainerStyle: Text.propTypes.style,
     arrowStyle: Text.propTypes.style,
@@ -75,6 +76,7 @@ export default class Carousel extends Component {
     bulletsContainerStyle: undefined,
     chosenBulletStyle: undefined,
     bulletStyle: undefined,
+    hideBulletsIndices: [],
     arrowsContainerStyle: undefined,
     arrowStyle: undefined,
     leftArrowStyle: undefined,
@@ -300,8 +302,8 @@ export default class Carousel extends Component {
 
   _renderBullets = (pageLength) => {
     const bullets = [];
-    let {currentPage} = this.state;
-    const { childrenLength } = this.state;
+    const { hideBulletsIndices } = this.props;
+    const { currentPage } = this.state;
 
     for (let i = 0; i < pageLength; i += 1) {
       bullets.push(
@@ -316,7 +318,7 @@ export default class Carousel extends Component {
     return (
       <View style={styles.bullets} pointerEvents="box-none">
         <View style={[styles.bulletsContainer, this.props.bulletsContainerStyle]} pointerEvents="box-none">
-          {currentPage === 0 || currentPage === childrenLength -1 ? <Text></Text> : bullets}
+          {!hideBulletsIndices.includes(currentPage) && bullets}
         </View>
       </View>
     );


### PR DESCRIPTION
Thought it was odd that bullets would automatically hide on the first and last pages - so I thought it'd be nice to give the users more freedom and specify which pages they want to hide the bullets. By default if `props.bullets` is true then the bullets will now display on all pages.